### PR TITLE
add commonly use node-to-element mapping routine

### DIFF
--- a/backend/src/environment/collision/collision_system.h
+++ b/backend/src/environment/collision/collision_system.h
@@ -182,15 +182,22 @@ void CollisionSystem<CoarseDetectionPolicy, FineDetectionPolicy, BatchingPolicy>
     const std::size_t n_nodes = positions.cols();
     const std::size_t n_elems = radii_elem.cols();
 
-    // Convert element radii to node radii (interpolate: node i gets radius from element floor(i/2))
-    // For nodes: node 0 and 1 share element 0, node 2 and 3 share element 1, etc.
+    // Convert element radii to node radii
+    // Treat entire block as a single rod - ghost nodes handle edge cases
+    // Mapping strategy for a rod with n_elems elements and n_nodes nodes:
+    // - Node 0 -> Element 0
+    // - Node i (1 to n_elems-1) -> Element i-1
+    // - Node i >= n_elems -> Element n_elems-1 (ghost nodes use last element)
     Eigen::MatrixXd radii(1, n_nodes);
     for (std::size_t i = 0; i < n_nodes; ++i) {
-        std::size_t elem_idx = (i < n_elems) ? i : (n_elems - 1);
-        if (i > 0 && i % 2 == 0 && elem_idx < n_elems - 1) {
-            elem_idx = i / 2;
-        } else if (i > 0) {
-            elem_idx = std::min(i / 2, n_elems - 1);
+        std::size_t elem_idx;
+        if (i == 0) {
+            elem_idx = 0;
+        } else if (i < n_elems) {
+            elem_idx = i - 1;
+        } else {
+            // For ghost nodes (i >= n_elems), use the last element
+            elem_idx = n_elems - 1;
         }
         radii(0, i) = radii_elem(0, elem_idx);
     }

--- a/backend/src/math/node_element_mapping.cpp
+++ b/backend/src/math/node_element_mapping.cpp
@@ -1,0 +1,120 @@
+#include "node_element_mapping.h"
+#include <stdexcept>
+#include <algorithm>
+
+namespace elasticapp {
+namespace math {
+
+std::size_t node_to_element_index(
+    std::size_t node_idx,
+    const std::vector<std::size_t>& rod_start_indices,
+    const std::vector<std::size_t>& rod_n_elems
+) {
+    if (rod_start_indices.empty() || rod_n_elems.empty()) {
+        throw std::invalid_argument("rod_start_indices and rod_n_elems cannot be empty");
+    }
+
+    // Find which rod this node belongs to
+    std::size_t rod_index = 0;
+    for (std::size_t i = 0; i < rod_start_indices.size(); ++i) {
+        if (i + 1 < rod_start_indices.size()) {
+            // Not the last rod
+            if (node_idx >= rod_start_indices[i] && node_idx < rod_start_indices[i + 1]) {
+                rod_index = i;
+                break;
+            }
+        } else {
+            // Last rod
+            if (node_idx >= rod_start_indices[i]) {
+                rod_index = i;
+                break;
+            }
+        }
+    }
+
+    // Check if node_idx is valid for the found rod
+    std::size_t rod_start = rod_start_indices[rod_index];
+    std::size_t rod_n_nodes = rod_n_elems[rod_index] + 1;  // n_elements + 1 nodes
+    std::size_t local_node_idx = node_idx - rod_start;
+
+    if (local_node_idx >= rod_n_nodes) {
+        throw std::out_of_range("node_idx is beyond the last node of its rod");
+    }
+
+    // Map local node index to local element index
+    // Strategy:
+    // - Node 0 -> Element 0
+    // - Node i (1 to n_elements-1) -> Element i-1
+    // - Node n_elements (last) -> Element n_elements-1
+    std::size_t local_elem_idx;
+    if (local_node_idx == 0) {
+        local_elem_idx = 0;
+    } else if (local_node_idx < rod_n_elems[rod_index]) {
+        local_elem_idx = local_node_idx - 1;
+    } else {
+        // Last node
+        local_elem_idx = rod_n_elems[rod_index] - 1;
+    }
+
+    // Convert to global element index
+    // Need to compute element start indices
+    std::size_t elem_start = 0;
+    for (std::size_t i = 0; i < rod_index; ++i) {
+        elem_start += rod_n_elems[i];
+    }
+
+    return elem_start + local_elem_idx;
+}
+
+std::pair<std::size_t, std::size_t> node_to_rod_and_element(
+    std::size_t node_idx,
+    const std::vector<std::size_t>& rod_start_indices,
+    const std::vector<std::size_t>& rod_n_elems
+) {
+    if (rod_start_indices.empty() || rod_n_elems.empty()) {
+        throw std::invalid_argument("rod_start_indices and rod_n_elems cannot be empty");
+    }
+
+    // Find which rod this node belongs to
+    std::size_t rod_index = 0;
+    for (std::size_t i = 0; i < rod_start_indices.size(); ++i) {
+        if (i + 1 < rod_start_indices.size()) {
+            // Not the last rod
+            if (node_idx >= rod_start_indices[i] && node_idx < rod_start_indices[i + 1]) {
+                rod_index = i;
+                break;
+            }
+        } else {
+            // Last rod
+            if (node_idx >= rod_start_indices[i]) {
+                rod_index = i;
+                break;
+            }
+        }
+    }
+
+    // Check if node_idx is valid for the found rod
+    std::size_t rod_start = rod_start_indices[rod_index];
+    std::size_t rod_n_nodes = rod_n_elems[rod_index] + 1;  // n_elements + 1 nodes
+    std::size_t local_node_idx = node_idx - rod_start;
+
+    if (local_node_idx >= rod_n_nodes) {
+        throw std::out_of_range("node_idx is beyond the last node of its rod");
+    }
+
+    // Map local node index to local element index
+    std::size_t local_elem_idx;
+    if (local_node_idx == 0) {
+        local_elem_idx = 0;
+    } else if (local_node_idx < rod_n_elems[rod_index]) {
+        local_elem_idx = local_node_idx - 1;
+    } else {
+        // Last node
+        local_elem_idx = rod_n_elems[rod_index] - 1;
+    }
+
+    return std::make_pair(rod_index, local_elem_idx);
+}
+
+} // namespace math
+} // namespace elasticapp

--- a/backend/src/math/node_element_mapping.h
+++ b/backend/src/math/node_element_mapping.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace elasticapp {
+namespace math {
+
+/**
+ * Map a global node index to the corresponding element index in a Block.
+ *
+ * For a rod with n_elements, there are n_elements+1 nodes.
+ * The mapping strategy:
+ * - For interior nodes (1 to n_elements-1): use the element before the node (element = node - 1)
+ * - For the first node (0): use element 0
+ * - For the last node (n_elements): use element n_elements-1
+ *
+ * This function handles multiple rods in a Block by using rod_start_indices
+ * to determine which rod a node belongs to.
+ *
+ * @param node_idx Global node index in the Block
+ * @param rod_start_indices Vector of starting node indices for each rod
+ * @param rod_n_elems Vector of number of elements for each rod
+ * @return Global element index corresponding to the node
+ * @throws std::out_of_range if node_idx is invalid
+ */
+std::size_t node_to_element_index(
+    std::size_t node_idx,
+    const std::vector<std::size_t>& rod_start_indices,
+    const std::vector<std::size_t>& rod_n_elems
+);
+
+/**
+ * Map a global node index to the corresponding element index within its rod.
+ *
+ * This is a helper function that first finds which rod the node belongs to,
+ * then maps it to the element index within that rod.
+ *
+ * @param node_idx Global node index in the Block
+ * @param rod_start_indices Vector of starting node indices for each rod
+ * @param rod_n_elems Vector of number of elements for each rod
+ * @return Pair of (rod_index, local_element_index)
+ * @throws std::out_of_range if node_idx is invalid
+ */
+std::pair<std::size_t, std::size_t> node_to_rod_and_element(
+    std::size_t node_idx,
+    const std::vector<std::size_t>& rod_start_indices,
+    const std::vector<std::size_t>& rod_n_elems
+);
+
+} // namespace math
+} // namespace elasticapp


### PR DESCRIPTION
### TL;DR

Added node-to-element mapping functionality for rod structures in the math module.

### What changed?

Added two new files to the backend math module:
- `node_element_mapping.h`: Defines two functions for mapping node indices to element indices
- `node_element_mapping.cpp`: Implements the mapping logic

The implementation provides two key functions:
1. `node_to_element_index`: Maps a global node index to its corresponding element index
2. `node_to_rod_and_element`: Maps a node index to a pair containing rod index and local element index

Both functions handle the special cases of first and last nodes in a rod, where the mapping follows specific rules:
- First node (0) maps to element 0
- Interior nodes map to the element before them
- Last node maps to the last element

### How to test?

Test the functions with various node indices, including:
- First node of a rod
- Interior nodes
- Last node of a rod
- Nodes in different rods within a block

Verify that error handling works correctly for:
- Empty rod data
- Node indices beyond valid ranges

### Why make this change?

This functionality is needed to properly associate nodes with elements in rod structures, which is essential for simulation calculations. The mapping is non-trivial because nodes and elements have different indexing schemes (n+1 nodes for n elements), and the system needs to handle edge cases like the first and last nodes of each rod.