### PR TITLE
add batching methods

### DIFF
--- a/backend/src/environment/collision/batching/union_find.cpp
+++ b/backend/src/environment/collision/batching/union_find.cpp
@@ -1,0 +1,105 @@
+#include "union_find.h"
+#include <algorithm>
+#include <unordered_map>
+
+namespace elasticapp {
+namespace collision {
+
+//==============================================================================
+// UnionFind::UnionFindDS Implementation
+//==============================================================================
+
+UnionFind::UnionFindDS::UnionFindDS(std::size_t max_node)
+    : parent_(max_node + 1), rank_(max_node + 1, 0) {
+    // Initialize: each node is its own parent (root)
+    for (std::size_t i = 0; i <= max_node; ++i) {
+        parent_[i] = i;
+    }
+}
+
+std::size_t UnionFind::UnionFindDS::find_root(std::size_t x) {
+    // Path compression: make parent point directly to root
+    if (parent_[x] != x) {
+        parent_[x] = find_root(parent_[x]);
+    }
+    return parent_[x];
+}
+
+void UnionFind::UnionFindDS::union_nodes(std::size_t x, std::size_t y) {
+    std::size_t root_x = find_root(x);
+    std::size_t root_y = find_root(y);
+
+    if (root_x == root_y) {
+        return;  // Already in same component
+    }
+
+    // Union by rank: attach smaller tree under larger tree
+    if (rank_[root_x] < rank_[root_y]) {
+        parent_[root_x] = root_y;
+    } else if (rank_[root_x] > rank_[root_y]) {
+        parent_[root_y] = root_x;
+    } else {
+        // Same rank: attach one to the other and increment rank
+        parent_[root_y] = root_x;
+        rank_[root_x]++;
+    }
+}
+
+//==============================================================================
+// UnionFind Implementation
+//==============================================================================
+
+std::vector<std::vector<std::size_t>> UnionFind::batch(
+    std::vector<Contact>& contacts
+) const {
+    const std::size_t n_contacts = contacts.size();
+
+    if (n_contacts == 0) {
+        return {};
+    }
+
+    // Step 1: Find maximum node index to size the Union-Find structure
+    std::size_t max_node = 0;
+    for (const auto& contact : contacts) {
+        max_node = std::max(max_node, std::max(contact.node1_idx, contact.node2_idx));
+    }
+
+    // Step 2: Initialize Union-Find data structure
+    UnionFindDS uf(max_node);
+
+    // Step 3: Union all nodes connected by contacts
+    // This builds the connected components: nodes connected by contacts are in the same component
+    for (const auto& contact : contacts) {
+        uf.union_nodes(contact.node1_idx, contact.node2_idx);
+    }
+
+    // Step 4: Group contacts by their root component and set their indices
+    // Contacts whose nodes share the same root are in the same batch
+    std::unordered_map<std::size_t, std::vector<std::size_t>> batches_map;
+    batches_map.reserve(n_contacts);  // Reserve space (worst case: one batch per contact)
+
+    for (std::size_t i = 0; i < n_contacts; ++i) {
+        auto& contact = contacts[i];
+        // Use root of node1 (both nodes in a contact have the same root after union)
+        std::size_t root = uf.find_root(contact.node1_idx);
+        auto& batch = batches_map[root];
+
+        // Set contact index to its position within the batch (matches reference implementation)
+        contact.set_index(batch.size());
+
+        // Add contact index to batch
+        batch.push_back(i);
+    }
+
+    // Step 5: Convert map to vector of batches
+    std::vector<std::vector<std::size_t>> batches;
+    batches.reserve(batches_map.size());
+    for (auto& [root, batch] : batches_map) {
+        batches.push_back(std::move(batch));
+    }
+
+    return batches;
+}
+
+} // namespace collision
+} // namespace elasticapp

--- a/backend/src/environment/collision/batching/union_find.h
+++ b/backend/src/environment/collision/batching/union_find.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "../types.h"
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace elasticapp {
+namespace collision {
+
+/**
+ * UnionFind batching policy.
+ *
+ * Groups contacts into batches using a Union-Find data structure.
+ * Based on the Elastica UnionFind batching implementation.
+ *
+ * Algorithm:
+ * 1. Build Union-Find structure on nodes: For each contact, union the two nodes it connects
+ * 2. Identify root nodes: Each connected component has a unique root
+ * 3. Group contacts by root: Contacts whose nodes share the same root are in the same batch
+ *
+ * This creates independent batches of contacts that can be processed in parallel,
+ * as contacts in different batches don't share any nodes and thus don't interfere.
+ *
+ * This is a CRTP policy class that will be mixed into CollisionSystem.
+ */
+class UnionFind {
+public:
+    /**
+     * Default constructor.
+     */
+    UnionFind() = default;
+
+    /**
+     * Destructor.
+     */
+    ~UnionFind() = default;
+
+    /**
+     * Group contacts into batches.
+     *
+     * Uses Union-Find to identify connected components of contacts.
+     * Contacts are connected if they share a common node (directly or transitively).
+     *
+     * Algorithm:
+     * 1. Initialize Union-Find: Each node is its own root initially
+     * 2. Union nodes: For each contact, union node1 and node2
+     * 3. Group contacts: Contacts whose nodes have the same root are grouped together
+     * 4. Set contact indices: Each contact's index is set to its position within its batch
+     *
+     * @param contacts Vector of all contacts (non-const to allow setting index)
+     * @return Vector of batches, where each batch is a vector of contact indices
+     */
+    std::vector<std::vector<std::size_t>> batch(
+        std::vector<Contact>& contacts
+    ) const;
+
+private:
+    /**
+     * Union-Find data structure for finding connected components.
+     */
+    class UnionFindDS {
+    public:
+        /**
+         * Constructor with maximum node index.
+         */
+        explicit UnionFindDS(std::size_t max_node);
+
+        /**
+         * Find root of a node with path compression.
+         */
+        std::size_t find_root(std::size_t x);
+
+        /**
+         * Union two nodes.
+         */
+        void union_nodes(std::size_t x, std::size_t y);
+
+    private:
+        std::vector<std::size_t> parent_;  // parent[i] = parent of node i
+        std::vector<std::size_t> rank_;    // rank[i] = approximate tree height (for union by rank)
+    };
+};
+
+} // namespace collision
+} // namespace elasticapp


### PR DESCRIPTION
### TL;DR

Implemented a Union-Find algorithm for contact batching in the collision system.

### What changed?

Added two new files implementing a Union-Find data structure and algorithm for batching collision contacts:
- `union_find.h`: Defines the UnionFind class with a nested UnionFindDS helper class
- `union_find.cpp`: Implements the batching algorithm that groups contacts into independent batches based on connected components

The implementation follows these steps:
1. Build a Union-Find structure on nodes, unioning nodes connected by contacts
2. Identify root nodes for each connected component
3. Group contacts by their root nodes into independent batches
4. Set contact indices within each batch

### How to test?

Test the UnionFind batching algorithm by:
1. Creating a set of collision contacts with overlapping nodes
2. Passing them to the `batch()` method
3. Verify that contacts sharing nodes are grouped in the same batch
4. Confirm that contacts in different batches don't share any nodes
5. Check that contact indices are set correctly within each batch

### Why make this change?

This implementation enables efficient parallel processing of collision contacts by grouping them into independent batches. Contacts in different batches don't share any nodes and can be processed concurrently without interference, improving performance for collision resolution in the physics simulation.