### PR TITLE
implement collision physics models: add NoInteraction and LinearSpringDashpot classes to the collision system

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -208,8 +208,8 @@ pybind11_add_module(_collision
     # "${SRC_DIR}/environment/collision/course_detection/hash_grid.cpp"
     # "${SRC_DIR}/environment/collision/fine_detection/max_contacts.cpp"
     # "${SRC_DIR}/environment/collision/batching/union_find.cpp"
-    # "${SRC_DIR}/environment/collision/physics/linear_spring_dashpot.cpp"
-    # "${SRC_DIR}/environment/collision/physics/no_interaction.cpp"
+    "${SRC_DIR}/environment/collision/physics/linear_spring_dashpot.cpp"
+    "${SRC_DIR}/environment/collision/physics/no_interaction.cpp"
     "${SRC_DIR}/math/node_element_mapping.cpp"
 )
 target_compile_definitions(_collision PRIVATE VERSION_INFO=${PROJECT_VERSION})

--- a/backend/src/environment/_api.cpp
+++ b/backend/src/environment/_api.cpp
@@ -4,6 +4,8 @@
 #include "../api.h"
 #include "api.h"
 #include "collision/collision_system.h"
+#include "collision/physics/no_interaction.h"
+#include "collision/physics/linear_spring_dashpot.h"
 
 namespace py = pybind11;
 
@@ -18,65 +20,65 @@ PYBIND11_MODULE(_collision, m) {
 
     using namespace elasticapp;
     using namespace elasticapp::environment::collision;
-    // using namespace elasticapp::collision::physics;
+    using namespace elasticapp::environment::collision::physics;
 
-    // NoInteraction model class (for testing)
-    // py::class_<physics::NoInteraction>(m, "NoInteraction")
-    //     .def(py::init<>(),
-    //         R"pbdoc(
-    //             Initialize a NoInteraction collision physics model.
+    NoInteraction model class (for testing)
+    py::class_<physics::NoInteraction>(m, "NoInteraction")
+        .def(py::init<>(),
+            R"pbdoc(
+                Initialize a NoInteraction collision physics model.
 
-    //             This model returns zero force for all contacts, useful for testing
-    //             collision detection without applying forces.
+                This model returns zero force for all contacts, useful for testing
+                collision detection without applying forces.
 
-    //             Args:
-    //                 None (no parameters required)
-    //         )pbdoc");
+                Args:
+                    None (no parameters required)
+            )pbdoc");
 
-    // // LinearSpringDashpot model class
-    // py::class_<physics::LinearSpringDashpot>(m, "LinearSpringDashpot")
-    //     .def(py::init<double, double, double>(),
-    //         R"pbdoc(
-    //             Initialize a LinearSpringDashpot collision physics model.
+    // LinearSpringDashpot model class
+    py::class_<physics::LinearSpringDashpot>(m, "LinearSpringDashpot")
+        .def(py::init<double, double, double>(),
+            R"pbdoc(
+                Initialize a LinearSpringDashpot collision physics model.
 
-    //             Args:
-    //                 k_normal: Normal spring constant for repulsion force
-    //                 eta_normal: Normal damping coefficient (also used for tangential damping)
-    //                 friction: Static friction coefficient
-    //         )pbdoc",
-    //         py::arg("k_normal") = 1.0,
-    //         py::arg("eta_normal") = 0.1,
-    //         py::arg("friction") = 0.5)
-    //     .def(py::init<double, double, double, double>(),
-    //         R"pbdoc(
-    //             Initialize a LinearSpringDashpot collision physics model with explicit tangential damping.
+                Args:
+                    k_normal: Normal spring constant for repulsion force
+                    eta_normal: Normal damping coefficient (also used for tangential damping)
+                    friction: Static friction coefficient
+            )pbdoc",
+            py::arg("k_normal") = 1.0,
+            py::arg("eta_normal") = 0.1,
+            py::arg("friction") = 0.5)
+        .def(py::init<double, double, double, double>(),
+            R"pbdoc(
+                Initialize a LinearSpringDashpot collision physics model with explicit tangential damping.
 
-    //             Args:
-    //                 k_normal: Normal spring constant for repulsion force
-    //                 eta_normal: Normal damping coefficient
-    //                 eta_tangential: Tangential damping coefficient
-    //                 friction: Static friction coefficient
-    //         )pbdoc",
-    //         py::arg("k_normal"),
-    //         py::arg("eta_normal"),
-    //         py::arg("eta_tangential"),
-    //         py::arg("friction"))
-    //     .def(py::init<double, double, double, double, double>(),
-    //         R"pbdoc(
-    //             Initialize a LinearSpringDashpot collision physics model with explicit tangential spring and damping.
+                Args:
+                    k_normal: Normal spring constant for repulsion force
+                    eta_normal: Normal damping coefficient
+                    eta_tangential: Tangential damping coefficient
+                    friction: Static friction coefficient
+            )pbdoc",
+            py::arg("k_normal"),
+            py::arg("eta_normal"),
+            py::arg("eta_tangential"),
+            py::arg("friction"))
+        .def(py::init<double, double, double, double, double>(),
+            R"pbdoc(
+                Initialize a LinearSpringDashpot collision physics model with explicit tangential spring and damping.
 
-    //             Args:
-    //                 k_normal: Normal spring constant for repulsion force
-    //                 eta_normal: Normal damping coefficient
-    //                 k_tangential: Tangential spring constant
-    //                 eta_tangential: Tangential damping coefficient
-    //                 friction: Static friction coefficient
-    //         )pbdoc",
-    //         py::arg("k_normal"),
-    //         py::arg("eta_normal"),
-    //         py::arg("k_tangential"),
-    //         py::arg("eta_tangential"),
-    //         py::arg("friction"));
+                Args:
+                    k_normal: Normal spring constant for repulsion force
+                    eta_normal: Normal damping coefficient
+                    k_tangential: Tangential spring constant
+                    eta_tangential: Tangential damping coefficient
+                    friction: Static friction coefficient
+            )pbdoc",
+            py::arg("k_normal"),
+            py::arg("eta_normal"),
+            py::arg("k_tangential"),
+            py::arg("eta_tangential"),
+            py::arg("friction"));
 
     // CollisionSystem class (using DefaultCollisionSystem)
     // Support both LinearSpringDashpot and NoInteraction models

--- a/backend/src/environment/collision/collision_system.h
+++ b/backend/src/environment/collision/collision_system.h
@@ -4,8 +4,8 @@
 #include "../../cosserat_rod_system.h"  // For system::cosserat_rod namespace
 #include "../../utility/hash.h"
 #include "concepts.hpp"
-// #include "physics/linear_spring_dashpot.h"
-// #include "physics/no_interaction.h"
+#include "physics/linear_spring_dashpot.h"
+#include "physics/no_interaction.h"
 #include "types.h"
 #include <variant>
 #include <type_traits>
@@ -51,8 +51,7 @@ public:
      * 2. Add it to this variant: using PhysicsModel = std::variant<...>;
      */
 
-    // using PhysicsModel = std::variant<physics::LinearSpringDashpot, physics::NoInteraction>;
-    using PhysicsModel = std::variant<std::nullptr_t>; // FIXME: not yet implemented
+    using PhysicsModel = std::variant<physics::LinearSpringDashpot, physics::NoInteraction, std::nullptr_t>;
 
     /**
      * Constructor takes a physics model and detection frequency.


### PR DESCRIPTION
# Uncomment and Enable Collision Physics Models

### TL;DR

Uncommented and enabled the `NoInteraction` and `LinearSpringDashpot` collision physics models in the Python bindings.

### What changed?

- Added include statements for `collision/physics/no_interaction.h` and `collision/physics/linear_spring_dashpot.h`
- Uncommented the Python bindings for `NoInteraction` and `LinearSpringDashpot` physics models
- Added the physics namespace to the using declarations
- Updated the `PhysicsModel` variant to include both physics models alongside the existing `std::nullptr_t`

### How to test?

1. Import the collision module in Python
2. Create instances of both physics models:
   ```python
   no_interaction = collision.NoInteraction()
   spring_dashpot = collision.LinearSpringDashpot(k_normal=1.0, eta_normal=0.1, friction=0.5)
   ```
3. Verify that the models can be used with the collision system

### Why make this change?

This change enables the use of previously implemented collision physics models that were commented out. By exposing these models through Python bindings, users can now specify different collision behaviors in their simulations, including a no-interaction model for testing collision detection without forces and a spring-dashpot model for realistic physical interactions.