### PR TITLE
fix namespaces: compilation issues

### DIFF
--- a/backend/src/environment/_api.cpp
+++ b/backend/src/environment/_api.cpp
@@ -22,7 +22,7 @@ PYBIND11_MODULE(_collision, m) {
     using namespace elasticapp::environment::collision;
     using namespace elasticapp::environment::collision::physics;
 
-    NoInteraction model class (for testing)
+    // NoInteraction model class (for testing)
     py::class_<physics::NoInteraction>(m, "NoInteraction")
         .def(py::init<>(),
             R"pbdoc(

--- a/backend/src/environment/collision/physics/linear_spring_dashpot.cpp
+++ b/backend/src/environment/collision/physics/linear_spring_dashpot.cpp
@@ -3,12 +3,11 @@
 #include <algorithm>
 #include <cmath>
 
-namespace elasticapp {
-namespace collision {
+namespace elasticapp::environment::collision {
 namespace physics {
 
 inline Eigen::Vector3d LinearSpringDashpot::compute_force(
-    const Contact& contact,
+    const collision::Contact& contact,
     double& penetration_depth
 ) const {
     // Check if contact is penetrating
@@ -83,11 +82,10 @@ inline Eigen::Vector3d LinearSpringDashpot::compute_force(
     return f_normal + f_tangential;
 }
 
-inline bool LinearSpringDashpot::is_penetrating(const Contact& contact) {
+inline bool LinearSpringDashpot::is_penetrating(const collision::Contact& contact) {
     // Contact is penetrating if distance < 0 (overlap)
     return contact.distance < 0.0;
 }
 
 } // namespace physics
-} // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment::collision

--- a/backend/src/environment/collision/physics/linear_spring_dashpot.h
+++ b/backend/src/environment/collision/physics/linear_spring_dashpot.h
@@ -2,13 +2,10 @@
 
 #include <Eigen/Dense>
 #include <cstddef>
+#include "../types.h"
 
-namespace elasticapp {
-namespace collision {
+namespace elasticapp::environment::collision {
 namespace physics {
-
-// Forward declaration - Contact will be defined in types.h
-struct Contact;
 
 /**
  * Linear spring-dashpot collision physics model.
@@ -112,7 +109,7 @@ struct LinearSpringDashpot {
      * @return Net force vector to apply to the first body (force on second body is -net_force)
      */
     inline Eigen::Vector3d compute_force(
-        const Contact& contact,
+        const collision::Contact& contact,
         double& penetration_depth
     ) const;
 
@@ -122,9 +119,8 @@ struct LinearSpringDashpot {
      * @param contact The contact information
      * @return True if bodies are penetrating (distance < 0)
      */
-    inline static bool is_penetrating(const Contact& contact);
+    inline static bool is_penetrating(const collision::Contact& contact);
 };
 
 } // namespace physics
-} // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment::collision

--- a/backend/src/environment/collision/physics/no_interaction.cpp
+++ b/backend/src/environment/collision/physics/no_interaction.cpp
@@ -1,12 +1,11 @@
 #include "no_interaction.h"
 #include "../types.h"
 
-namespace elasticapp {
-namespace collision {
+namespace elasticapp::environment::collision {
 namespace physics {
 
 inline Eigen::Vector3d NoInteraction::compute_force(
-    const Contact& contact,
+    const collision::Contact& contact,
     double& penetration_depth
 ) const {
     // No interaction - always return zero force
@@ -15,5 +14,4 @@ inline Eigen::Vector3d NoInteraction::compute_force(
 }
 
 } // namespace physics
-} // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment::collision

--- a/backend/src/environment/collision/physics/no_interaction.h
+++ b/backend/src/environment/collision/physics/no_interaction.h
@@ -2,13 +2,10 @@
 
 #include <Eigen/Dense>
 #include <cstddef>
+#include "../types.h"
 
-namespace elasticapp {
-namespace collision {
+namespace elasticapp::environment::collision {
 namespace physics {
-
-// Forward declaration - Contact will be defined in types.h
-struct Contact;
 
 /**
  * NoInteraction physics model for testing purposes.
@@ -35,11 +32,10 @@ struct NoInteraction {
      * @return Zero force vector
      */
     inline Eigen::Vector3d compute_force(
-        const Contact& contact,
+        const collision::Contact& contact,
         double& penetration_depth
     ) const;
 };
 
 } // namespace physics
-} // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment::collision


### PR DESCRIPTION
### TL;DR

Fixed a comment syntax error and updated namespace declarations in collision physics files.

### What changed?

- Fixed a missing comment delimiter in `_api.cpp` by adding `//` to properly comment out "NoInteraction model class (for testing)"
- Updated namespace declarations in physics files to use the more concise C++17 nested namespace syntax (`namespace elasticapp::environment::collision`)
- Added proper includes for `types.h` instead of using forward declarations for the `Contact` struct
- Updated function parameter types to use fully qualified `collision::Contact` to avoid ambiguity

### How to test?

Compile the codebase to verify that the syntax errors have been fixed. The functionality should remain unchanged as these are purely syntactic improvements.

### Why make this change?

These changes improve code consistency and readability by:
1. Fixing a syntax error that could cause compilation issues
2. Using modern C++ namespace syntax
3. Properly including dependencies rather than relying on forward declarations
4. Making type references more explicit to prevent potential namespace conflicts