### PR TITLE
fix build: correct namespace from upstream redefinitions

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Compiler flags
-add_compile_options(-Wno-unused)
+add_compile_options(-Wno-unused -fdiagnostics-color=always -Wall -Wextra -pedantic -flto)
 
 # Find Python and pybind11 (temp)
 # pybind11 will find Python and NumPy automatically
@@ -205,9 +205,9 @@ install(TARGETS version
 # Extension module: _collision (Python module name)
 pybind11_add_module(_collision
     "${SRC_DIR}/environment/_api.cpp"
-    # "${SRC_DIR}/environment/collision/course_detection/hash_grid.cpp"
-    # "${SRC_DIR}/environment/collision/fine_detection/max_contacts.cpp"
-    # "${SRC_DIR}/environment/collision/batching/union_find.cpp"
+    "${SRC_DIR}/environment/collision/course_detection/hash_grid.cpp"
+    "${SRC_DIR}/environment/collision/fine_detection/max_contacts.cpp"
+    "${SRC_DIR}/environment/collision/batching/union_find.cpp"
     "${SRC_DIR}/environment/collision/physics/linear_spring_dashpot.cpp"
     "${SRC_DIR}/environment/collision/physics/no_interaction.cpp"
     "${SRC_DIR}/math/node_element_mapping.cpp"
@@ -239,6 +239,7 @@ install(TARGETS _collision
 # Install Python package files
 install(FILES
         "${PYTHON_PACKAGE_DIR}/__init__.py"
+        "${PYTHON_PACKAGE_DIR}/typing_alias.py"
         "${PYTHON_PACKAGE_DIR}/memory_block_rod.py"
         "${PYTHON_PACKAGE_DIR}/collision_physics.py"
         "${PYTHON_PACKAGE_DIR}/module_collision.py"

--- a/backend/src/environment/collision/batching/union_find.cpp
+++ b/backend/src/environment/collision/batching/union_find.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <unordered_map>
 
-namespace elasticapp {
+namespace elasticapp::environment {
 namespace collision {
 
 //==============================================================================
@@ -102,4 +102,4 @@ std::vector<std::vector<std::size_t>> UnionFind::batch(
 }
 
 } // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment

--- a/backend/src/environment/collision/batching/union_find.h
+++ b/backend/src/environment/collision/batching/union_find.h
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
-namespace elasticapp {
+namespace elasticapp::environment {
 namespace collision {
 
 /**
@@ -83,4 +83,4 @@ private:
 };
 
 } // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment

--- a/backend/src/environment/collision/concepts.hpp
+++ b/backend/src/environment/collision/concepts.hpp
@@ -6,7 +6,7 @@
 #include <cstddef>
 #include <Eigen/Dense>
 #include "types.h"
-// #include "physics/linear_spring_dashpot.h"
+#include "physics/linear_spring_dashpot.h"
 
 namespace elasticapp::environment {
 namespace collision {
@@ -65,7 +65,7 @@ concept FineDetectionPolicyFor = requires(
  * This is checked by requiring it to work with at least one model type (LinearSpringDashpot).
  */
 template<typename T>
-concept FineDetectionPolicy = FineDetectionPolicyFor<T, std::nullptr_t>; //physics::LinearSpringDashpot>;
+concept FineDetectionPolicy = FineDetectionPolicyFor<T, physics::LinearSpringDashpot>;
 
 /**
  * Concept for BatchingPolicy.
@@ -80,7 +80,7 @@ concept FineDetectionPolicy = FineDetectionPolicyFor<T, std::nullptr_t>; //physi
 template<typename T>
 concept BatchingPolicy = requires(
     T policy,
-    const std::vector<Contact>& contacts
+    std::vector<Contact>& contacts
 ) {
     // Must have a batch method that takes contacts and returns batches
     { policy.batch(contacts) } -> std::convertible_to<std::vector<std::vector<std::size_t>>>;

--- a/backend/src/environment/collision/course_detection/hash_grid.cpp
+++ b/backend/src/environment/collision/course_detection/hash_grid.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <limits>
 
-namespace elasticapp {
+namespace elasticapp::environment {
 namespace collision {
 
 //==============================================================================
@@ -333,7 +333,7 @@ void HashGrid::clear() {
 std::vector<std::pair<std::size_t, std::size_t>> HashGrid::detect(
     const Eigen::MatrixXd& positions,
     const Eigen::MatrixXd& radii
-) const {
+) {
     const Eigen::Index n_nodes = positions.cols();
 
     if (n_nodes == 0) {
@@ -436,4 +436,4 @@ std::vector<std::pair<std::size_t, std::size_t>> HashGrid::detect(
 }
 
 } // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment

--- a/backend/src/environment/collision/course_detection/hash_grid.h
+++ b/backend/src/environment/collision/course_detection/hash_grid.h
@@ -12,7 +12,7 @@
 #include <cmath>
 #include <cstdint>
 
-namespace elasticapp {
+namespace elasticapp::environment {
 namespace collision {
 
 /**
@@ -80,7 +80,7 @@ public:
     std::vector<std::pair<std::size_t, std::size_t>> detect(
         const Eigen::MatrixXd& positions,
         const Eigen::MatrixXd& radii
-    ) const;
+    );
 
     /**
      * Clear all grids (for reuse).
@@ -259,4 +259,4 @@ private:
 };
 
 } // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment

--- a/backend/src/environment/collision/fine_detection/max_contacts.cpp
+++ b/backend/src/environment/collision/fine_detection/max_contacts.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <cmath>
 
-namespace elasticapp {
+namespace elasticapp::environment {
 namespace collision {
 
 std::vector<Contact> MaxContacts::detect_sphere_sphere(
@@ -75,4 +75,4 @@ std::vector<Contact> MaxContacts::detect_sphere_sphere(
 // Template implementation moved to header file (max_contacts.h) due to template nature
 
 } // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment

--- a/backend/src/environment/collision/fine_detection/max_contacts.h
+++ b/backend/src/environment/collision/fine_detection/max_contacts.h
@@ -7,7 +7,7 @@
 
 #include <omp.h>
 
-namespace elasticapp {
+namespace elasticapp::environment {
 namespace collision {
 
 /**
@@ -183,4 +183,4 @@ private:
 };
 
 } // namespace collision
-} // namespace elasticapp
+} // namespace elasticapp::environment

--- a/backend/src/py/collision_physics.py
+++ b/backend/src/py/collision_physics.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from elasticapp._memory_block import BlockRodSystem
 from elasticapp._collision import CollisionSystem
 
-from .module_collision import CoarseDetectionType, FineDetectionType, BatchingType
+from .typing_alias import CoarseDetectionType, FineDetectionType, BatchingType
 
 
 class CollisionPhysics(ABC):
@@ -13,9 +13,9 @@ class CollisionPhysics(ABC):
 
     def __init__(
         self,
-        coarse_detection: CoarseDetectionType,
-        fine_detection: FineDetectionType,
-        batching: BatchingType,
+        coarse_detection: CoarseDetectionType = "hash_grid",
+        fine_detection: FineDetectionType = "sphere_sphere",
+        batching: BatchingType = "union_find",
     ) -> None:
         super().__init__()
         self.coarse_detection = coarse_detection

--- a/backend/src/py/module_collision.py
+++ b/backend/src/py/module_collision.py
@@ -8,7 +8,7 @@ Provides the collision environment interface to configure collision detection an
 detection resolution for Cosserat rods in the simulation.
 """
 __all__ = ["CollisionEnvironment"]
-from typing import Any, Type, Literal
+from typing import Any, Type
 import functools
 
 from elastica.external_forces import NoForces
@@ -18,9 +18,7 @@ from elastica.modules.protocol import SystemCollectionProtocol, ModuleProtocol
 from .memory_block_rod import MemoryBlockCosseratRod
 from .collision_physics import CollisionPhysics
 
-CoarseDetectionType = Literal["hash_grid"]
-FineDetectionType = Literal["sphere_sphere"]
-BatchingType = Literal["union_find"]  # , "single_batch", "hybrid_batch"]
+from .typing_alias import CoarseDetectionType, FineDetectionType, BatchingType
 
 
 class CollisionEnvironment(SystemCollectionProtocol):

--- a/backend/src/py/typing_alias.py
+++ b/backend/src/py/typing_alias.py
@@ -1,0 +1,5 @@
+from typing import Literal
+
+CoarseDetectionType = Literal["hash_grid"]
+FineDetectionType = Literal["sphere_sphere"]
+BatchingType = Literal["union_find"]  # , "single_batch", "hybrid_batch"]

--- a/backend/tests/cpp/collision/test_collision_system.cpp
+++ b/backend/tests/cpp/collision/test_collision_system.cpp
@@ -10,9 +10,7 @@
 
 using Catch::Approx;
 
-namespace elasticapp {
-namespace environment {
-namespace collision {
+namespace elasticapp::environment::collision {
 namespace testing {
 
 /**
@@ -58,7 +56,7 @@ struct NullFineDetection {
  */
 struct NullBatching {
     std::vector<std::vector<std::size_t>> batch(
-        const std::vector<Contact>& contacts
+        std::vector<Contact>& contacts
     ) const {
         (void)contacts;
         return {};
@@ -66,9 +64,7 @@ struct NullBatching {
 };
 
 } // namespace testing
-} // namespace collision
-} // namespace environment
-} // namespace elasticapp
+} // namespace elasticapp::environment::collision
 
 // Type alias for test CollisionSystem with null policies
 using TestCollisionSystem = elasticapp::environment::collision::CollisionSystem<


### PR DESCRIPTION
### TL;DR

Enabled collision detection components and improved compiler flags for better code quality.

### What changed?

- Added additional compiler flags (`-fdiagnostics-color=always`, `-Wall`, `-Wextra`, `-pedantic`, `-flto`) to improve code quality and diagnostics
- Uncommented and enabled collision detection components in CMakeLists.txt:
  - Course detection (hash grid)
  - Fine detection (max contacts)
  - Batching (union find)
- Fixed namespace declarations in collision-related files to use `elasticapp::environment` consistently
- Modified the `detect` method in HashGrid to be non-const
- Updated the `batch` method parameter in BatchingPolicy concept to accept non-const references
- Created a new `typing_alias.py` file to centralize type definitions
- Added default values for collision detection parameters in `CollisionPhysics` class

### How to test?

1. Build the project with the updated compiler flags
2. Verify that collision detection works properly by running tests
3. Check that the Python interface correctly uses the default collision detection parameters

### Why make this change?

This change enables the previously disabled collision detection components, making them available for use in the simulation. The namespace updates ensure consistency across the codebase, while the additional compiler flags help catch potential issues early. Moving type definitions to a separate file improves code organization and maintainability.